### PR TITLE
fix: schema - move req field modeOfStudy from programOffering to program

### DIFF
--- a/rio/profile/schemas/Program.yaml
+++ b/rio/profile/schemas/Program.yaml
@@ -6,6 +6,7 @@ required:
   - description
   - primaryCode
   - teachingLanguage
+  - modeOfStudy
   - validFrom
   - educationSpecification
   - duration

--- a/rio/profile/schemas/ProgramOfferingProperties.yaml
+++ b/rio/profile/schemas/ProgramOfferingProperties.yaml
@@ -1,6 +1,5 @@
 type: object
 required:
-  - modeOfStudy
   - startDate
   - endDate
 properties:


### PR DESCRIPTION
Validating endpoint demo04 with profile rio resulted in errors for programOfferings:

```
GET /programs/0c405c0e-8f94-4f2f-5b1e-e597e8e1088a/offerings
Missing required field(s): modeOfStudy at response / body / items / 0
```
According to ooapi v5 spec, there is no modeOfStudy attribute in programOffering.
It seems that the required field `modeOfStudy` belongs to the program schema.